### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
 - 'ftp-client'
 - 'ftp-client-conduit'
 extra-deps: []
+pvp-bounds: both


### PR DESCRIPTION
This automatically sets the meta-data in the generated src tarballs more accurately and reduces the
risk of this package's meta-data bitrotting over time.

See also https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds