### PR TITLE
Tightening lower bound on `base`

### DIFF
--- a/ftp-client/ftp-client.cabal
+++ b/ftp-client/ftp-client.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Network.FTP.Client
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , bytestring
                      , network
                      , attoparsec >= 0.10


### PR DESCRIPTION
This is because `ftp-client` currently doesn't support GHC 7.8's `base` (see below)

And at this point with GHC 8.2 around the corner there's probably little benefit in adding support for the rather old GHC 7.8

```
Preprocessing library ftp-client-0.2.0.0...
[1 of 1] Compiling Network.FTP.Client ( src/Network/FTP/Client.hs, dist/build/Network/FTP/Client.o )

src/Network/FTP/Client.hs:482:24:
    Not in scope: ‘*>’
    Perhaps you meant one of these:
      ‘*’ (imported from Prelude), ‘<>’ (imported from Data.Monoid),
      ‘<*>’ (imported from Control.Applicative)
cabal: Failed to build ftp-client-0.2.0.0 (which is required by
ftp-client-conduit-0.2.0.0). See the build log above for details.
```