### PR TITLE
Bugfix "MonadFail" errors w/ ghc 8.6; fix test suite decls

### DIFF
--- a/example/example.cabal
+++ b/example/example.cabal
@@ -29,7 +29,6 @@ test-suite example-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
-                     , example
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/ftp-client-conduit/ftp-client-conduit.cabal
+++ b/ftp-client-conduit/ftp-client-conduit.cabal
@@ -30,7 +30,7 @@ test-suite ftp-conduit-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
-                     , ftp-clientconduit
+                     , ftp-client-conduit
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
When compiling with ghc-8.6, I was seeing the following sorts of errors:

```
Could not deduce (Control.Monad.Fail.MonadFail m)
        arising from a do statement
        with the failable pattern
```

See: https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#MonadFailDesugaringbydefault

The quick 'n easy way to address this was to push each failable patterns *inside* of the `liftIO` block, since even though monad `m` isn't known to be an instance of `MonadFail`, we can simply rely on the `IO` instance.

This PR also cleans up the cabal files so that the test suites (stubs though they are) can be built and run. For `example.cabal`, there is no library component; the test suite cannot depend on a library that isn't there. For `ftp-client-conduit.cabal`, there was a typo.

I was able to successfully build these changes against the original stack.yaml in the repo, as well as the following (to test with ghc 8.6):

```yaml
# stack.yaml
resolver: nightly-2018-10-10
packages:
- 'ftp-client'
- 'ftp-client-conduit'
- 'example'
pvp-bounds: both
extra-deps:
# deps for ftp-client
- connection-0.2.8@sha256:80671b805383147d41bc099a2b591442da5659d075b17f528c4729a39c99d6d8
# deps for connection
- byteable-0.1.1@sha256:12eeda93251d4b5d510ac95cf578f5c89d4a399b14ca73116deaf4921a516fdf
- tls-1.4.1@sha256:10087515f118d29938c3442b1255c10e0c866efa3639b3813dfb9755a8f89d86
- x509-1.7.4@sha256:dfc5cc9617dc084c5560dff230644da009e1a63dd71bc954f5c8a210e4ff3f5d
- x509-store-1.6.6@sha256:5503bf2d77f5d7349e92b3961cbfab9cdbb48a310a4ac74b22069c3b6c18f4d8
- x509-system-1.6.6@sha256:3a1b9cc26715d7cb3cd1a3f8b6153f12c2d42187ac5df305c3973c78a061db05
- x509-validation-1.6.10@sha256:1c50be76040e7a02b1cf6ca8a2806aa159a47c29c1be212fc161c01736ba4ac7
# deps for tls
- asn1-encoding-0.9.5@sha256:7d4acf178ef17aad650f2073dd2ed94febb1e468fddb0d5ca65c1a54caffcfb8
- asn1-parse-0.9.4@sha256:748249e23024dde8fed1d99e85e7e952576ce51b3ce460b9d131b2e91ff9c5a4
- asn1-types-0.3.2@sha256:2fc0d64079e9ac9ec7f349aa65c1775acb060f19601deee129a9769fdcf8f07a
- pem-0.2.4@sha256:cc8e62118b783e284dc0fa032f54fe386a3861a948ec88079370a433c103a705
```