### PR TITLE
fix multiline response

### DIFF
--- a/ftp-client/src/Network/FTP/Client.hs
+++ b/ftp-client/src/Network/FTP/Client.hs
@@ -268,7 +268,8 @@ loopMultiLine h code lines = do
     nextLine <- liftIO $ getLineResp h
     let newLines = lines <> [C.dropWhile (== ' ') nextLine]
         nextCode = C.take 3 nextLine
-    if nextCode == code
+        continue = C.head $ C.drop 3 nextLine
+    if nextCode == code && continue /= '-'
         then return newLines
         else loopMultiLine h code newLines
 


### PR DESCRIPTION
I'm a bit of a Haskell n00b - this is my first PR.

I was trying to use ftp-client to look at `ftp.bom.gov.au` but it was failing on the welcome message. It seemed to not read the entire message. This small change fixed that problem. I'm not sure if it is a broadly valid solution (I suspect it might fail on a line that contains _only_ the status code and no other chars). Not sure how to test that.

I would write some tests...but I haven't gotten that far with Haskell yet.
