### PR TITLE
Minimal test dependencies

### DIFF
--- a/ftp-client/ftp-client.cabal
+++ b/ftp-client/ftp-client.cabal
@@ -32,8 +32,7 @@ test-suite ftp-client-test
   main-is:             test.hs
   build-depends:       base >=4.11.1.0 && < 5
                      , bytestring
-                     , tasty >= 1.2.3
-                     , tasty-hspec >= 1.1.5.1
+                     , hspec >= 2.7
                      , ftp-client
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/ftp-client/test/test.hs
+++ b/ftp-client/test/test.hs
@@ -1,7 +1,6 @@
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as C
-import Test.Tasty
-import Test.Tasty.Hspec
+import Test.Hspec
 import Network.FTP.Client hiding (Success)
 import qualified Network.FTP.Client as F
 import Control.Monad.IO.Class


### PR DESCRIPTION
The test dependencies required and imported are actually all simply from hspec. So let's change the cabal file to require what it actually needs.

First, I ran the test on GHC 8.6 (with the minimal Hspec version):

```
janus@gorm ~/flipstone/ftp-client/ftp-client
 % cabal test --constraint='hspec==2.7.0' -w ghc-8.6.5
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - ftp-client-0.5.1.4 (lib) (configuration changed)
 - ftp-client-0.5.1.4 (test:ftp-client-test) (configuration changed)
Configuring library for ftp-client-0.5.1.4..
Preprocessing library for ftp-client-0.5.1.4..
Building library for ftp-client-0.5.1.4..
Configuring test suite 'ftp-client-test' for ftp-client-0.5.1.4..
Preprocessing test suite 'ftp-client-test' for ftp-client-0.5.1.4..
Building test suite 'ftp-client-test' for ftp-client-0.5.1.4..
[1 of 1] Compiling Main             ( test/test.hs, /home/janus/flipstone/ftp-client/ftp-client/dist-newstyle/build/x86_64-linux/ghc-8.6.5/ftp-client-0.5.1.4/t/ftp-client-test/build/ftp-client-test/ftp-client-test-tmp/Main.o )
Linking /home/janus/flipstone/ftp-client/ftp-client/dist-newstyle/build/x86_64-linux/ghc-8.6.5/ftp-client-0.5.1.4/t/ftp-client-test/build/ftp-client-test/ftp-client-test ...
Running 1 test suites...
Test suite ftp-client-test: RUNNING...
Test suite ftp-client-test: PASS
Test suite logged to:
/home/janus/flipstone/ftp-client/ftp-client/dist-newstyle/build/x86_64-linux/ghc-8.6.5/ftp-client-0.5.1.4/t/ftp-client-test/test/ftp-client-0.5.1.4-ftp-client-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

Then, I ran the test on GHC 9.2.1 and with the newest Hspec:

```
janus@gorm ~/flipstone/ftp-client/ftp-client
 % cabal test --constraint='hspec==2.9.4' -w ghc-9.2.1
Resolving dependencies...
Build profile: -w ghc-9.2.1 -O1
In order, the following will be built (use -v for more details):
 - ftp-client-0.5.1.4 (lib) (configuration changed)
 - ftp-client-0.5.1.4 (test:ftp-client-test) (configuration changed)
Configuring library for ftp-client-0.5.1.4..
Preprocessing library for ftp-client-0.5.1.4..
Building library for ftp-client-0.5.1.4..
Configuring test suite 'ftp-client-test' for ftp-client-0.5.1.4..
Preprocessing test suite 'ftp-client-test' for ftp-client-0.5.1.4..
Building test suite 'ftp-client-test' for ftp-client-0.5.1.4..
Running 1 test suites...
Test suite ftp-client-test: RUNNING...
Test suite ftp-client-test: PASS
Test suite logged to:
/home/janus/flipstone/ftp-client/ftp-client/dist-newstyle/build/x86_64-linux/ghc-9.2.1/ftp-client-0.5.1.4/t/ftp-client-test/test/ftp-client-0.5.1.4-ftp-client-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```
